### PR TITLE
Added logic to set a macro's icon to be dynamic if it starts with '#showtooltip'.

### DIFF
--- a/Restore.lua
+++ b/Restore.lua
@@ -106,14 +106,16 @@ function addon:UseProfile(profile, check, cache)
     return res.fail, res.total
 end
 
--- if a macro starts with "#showtooltip", reset icon to the question mark so they can be dynamic
+-- if a macro starts with "#showtooltip", and has no argument, reset icon to the question mark so they can be dynamic
+-- More info about #showtooltip here: https://warcraft.wiki.gg/wiki/MACRO_metashowtooltip
 function addon:RefreshMacroIcons()
     for index = 1, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
         name, icon, body = GetMacroInfo(index)
-        if body and strsub(body, 0, 12) == "#showtooltip" then
+        local bodyWithoutSpaces = string.gsub(body, "%s+", "")
+        if string.sub(bodyWithoutSpaces, 0, 13) == "#showtooltip/" then
             index = EditMacro(index, name, 134400, body) -- 134400 is the question mark icon
         end
-    end
+     end
 end
 
 -- Function to restore macros based on a given profile, with an option to check without actually applying the changes

--- a/Restore.lua
+++ b/Restore.lua
@@ -100,10 +100,21 @@ function addon:UseProfile(profile, check, cache)
         self:UpdateGUI()
     end
 
+    self:RefreshMacroIcons()
+
     -- Return the number of failed and total restoration attempts
     return res.fail, res.total
 end
 
+-- if a macro starts with "#showtooltip", reset icon to the question mark so they can be dynamic
+function addon:RefreshMacroIcons()
+    for index = 1, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
+        name, icon, body = GetMacroInfo(index)
+        if body and strsub(body, 0, 12) == "#showtooltip" then
+            index = EditMacro(index, name, 134400, body) -- 134400 is the question mark icon
+        end
+    end
+end
 
 -- Function to restore macros based on a given profile, with an option to check without actually applying the changes
 function addon:RestoreMacros(profile, check, cache, res)

--- a/Restore.lua
+++ b/Restore.lua
@@ -111,9 +111,11 @@ end
 function addon:RefreshMacroIcons()
     for index = 1, MAX_ACCOUNT_MACROS + MAX_CHARACTER_MACROS do
         name, icon, body = GetMacroInfo(index)
-        local bodyWithoutSpaces = string.gsub(body, "%s+", "")
-        if string.sub(bodyWithoutSpaces, 0, 13) == "#showtooltip/" then
-            index = EditMacro(index, name, 134400, body) -- 134400 is the question mark icon
+        if body then
+            local bodyWithoutSpaces = string.gsub(body, "%s+", "")
+            if string.sub(bodyWithoutSpaces, 0, 13) == "#showtooltip/" then
+                index = EditMacro(index, name, 134400, body) -- 134400 is the question mark icon
+            end
         end
      end
 end


### PR DESCRIPTION
Currently, if a macro has '#showtooltip' without an argument, the icon is set to the first ability or item in the macro. To make the macro icon dynamic again, you have to change the icon to the question mark. This can be tedious if you have a lot of macros that start with '#showtooltip'. The logic I am introducing checks to see if the macro starts with '#showtooltip' without an argument and sets the icon to the question mark icon.